### PR TITLE
Bump JWT gem to v2.2

### DIFF
--- a/althea_passport.gemspec
+++ b/althea_passport.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
 
   spec.add_dependency "http", ">= 4.4"
-  spec.add_dependency "jwt", "~> 1.5"
+  spec.add_dependency "jwt", "~> 2.2"
 end

--- a/lib/althea_passport/version.rb
+++ b/lib/althea_passport/version.rb
@@ -1,3 +1,3 @@
 module AltheaPassport
-  VERSION = '0.8.5'
+  VERSION = '0.9.2'
 end


### PR DESCRIPTION
I think we can merge this PR.

once it is merged, we should update calendar+transitions+generations+patient_forms app and in each of them remove the `ref`:
* https://github.com/Kindbody/all_rails/blob/master/calendar/Gemfile#L13
* https://github.com/Kindbody/all_rails/blob/master/generations/Gemfile#L8
* https://github.com/Kindbody/all_rails/blob/master/transitions/Gemfile#L8
* https://github.com/Kindbody/PatientForms/blob/b884e2784c7d62fab8bf3a5a232bbcec44d3e5fe/Gemfile#L12

identifications app is not using ref, so that one should just pick up the new master:
* https://github.com/Kindbody/identifications/blob/master/Gemfile#L9

I don't think there is any other app using this gem.

if something goes wrong after merge, it could be only the identifications app, because all other apps are already using this branch. 

-------

changelog:

P. V.: at 2021-03-26,  I simplified this PR to differ  from `master` only by the jwt version, and labeled this change as v 0.9.2. Before my change, this PR had version 0.9.1, and it used the libraries from [this PR, which I think we will abandon](https://github.com/Kindbody/althea_passport/pull/4). The version 0.9.2 should be adopted [automatically by calendar app](https://github.com/Kindbody/all_rails/blob/master/calendar/Gemfile#L13)


---

We need the changes here for this PR: https://github.com/Kindbody/all_rails/pull/2466 which is using which is using `JWT::JWK::RSA.import` method that does not exists in `jwt` gem v1.5.

but we cannot merge this PR, because then all other apps (generations/transitions/who-knows-which-other-apps..) will start failing within `bundle install` due to the `jwt` version mismatch.


```
Bundler could not find compatible versions for gem "jwt":
  In snapshot (Gemfile.lock):
    jwt (= 1.5.6)

  In Gemfile:
    althea_passport was resolved to 0.8.3, which depends on
      jwt (~> 2.2)

    pokitdok-ruby (~> 0.9.0) was resolved to 0.9.2, which depends on
      oauth2 (~> 1.0) was resolved to 1.4.2, which depends on
        jwt (>= 1.0, < 3.0)
```

so the solution is:  calendar app will start using althea_passport gem from `branch: 'bump-jwt-gem-to-2.2'`, while all other apps remain with the `master` version of the gem.

### QA notes

the only place where the JWT library is used is in [token_coder.rb](https://github.com/Kindbody/althea_passport/blob/master/lib/althea_passport/token_coder.rb).

The signature of JWT.encode and JWT.decode is that same for 1.5 and 2.2, and there is also [rspec](https://github.com/Kindbody/althea_passport/blob/master/test/althea-passport/token_coder_test.rb) which is passing on this PR.. so jwt v2.2 seem to work fine within `althea_passport` gem.
